### PR TITLE
Find real client IP address

### DIFF
--- a/index.php
+++ b/index.php
@@ -19,7 +19,15 @@ function looks_like_ip ($ip) {
 }
 
 function get_ip () {
-  return $_SERVER['REMOTE_ADDR'];
+  if (! empty($_SERVER['HTTP_CLIENT_IP'])) {
+    $ip = $_SERVER['HTTP_CLIENT_IP'];
+  } elseif (! empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+    $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+  } else {
+    $ip = $_SERVER['REMOTE_ADDR'];
+  }
+
+  return $ip;
 }
 
 function get_product_id () {


### PR DESCRIPTION
If client is use proxy server then `REMOTE_ADDR` returns the IP address of the proxy server, not of the client’s machine.